### PR TITLE
Update PurgeCSS safelist to protect JS injected css selectors

### DIFF
--- a/assets/js/mermaid.js
+++ b/assets/js/mermaid.js
@@ -1,0 +1,11 @@
+import mermaid from 'mermaid';
+
+var config = {
+  theme: 'default',
+  fontFamily: '"OpenSans", -apple-system, blinkmacsystemfont, "Segoe UI", roboto, "Helvetica Neue", arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";',
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  mermaid.initialize(config);
+  mermaid.init(undefined, '.language-mermaid');
+});

--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -44,6 +44,7 @@ module:
         - scss/common/_variables.scss
         - scss/common/_fonts.scss
         - js/highlight.js
+        - js/mermaid.js
     - source: node_modules/font-awesome/scss
       target: assets/scss/font-awesome
 

--- a/config/postcss.config.js
+++ b/config/postcss.config.js
@@ -10,7 +10,7 @@ const safelist = [
   // Details shortcode
   'disappear',
   'open',
-  // Global announcment
+  // Global announcement
   'announcement',
   'data-global-alert',
   // Content headers

--- a/config/postcss.config.js
+++ b/config/postcss.config.js
@@ -14,6 +14,7 @@ const safelist = [
   // Highlight JS
   'hljs',
   /^hljs-.*/,
+  'btn-copy',
   // Search bar
   'suggestions',
   /suggestion__.*/,

--- a/config/postcss.config.js
+++ b/config/postcss.config.js
@@ -2,14 +2,18 @@ const autoprefixer = require('autoprefixer');
 const purgecss = require('@fullhuman/postcss-purgecss');
 
 const safelist = [
-  // DOM attributes
+  // Dark mode
   'data-dark-mode',
+  // Codelab sidebar selectors
   'completed',
   'selected',
+  // Details shortcode
   'disappear',
   'open',
+  // Global announcment
   'announcement',
   'data-global-alert',
+  // Content headers
   'id',
   // Highlight JS
   'hljs',

--- a/config/postcss.config.js
+++ b/config/postcss.config.js
@@ -11,6 +11,11 @@ const attributes = [
   'id'
 ];
 
+const highlightJs = [
+  'hljs',
+  /^hljs-.*/
+];
+
 module.exports = {
   plugins: [
     autoprefixer(),
@@ -22,10 +27,12 @@ module.exports = {
           ...(els.tags || []),
           ...(els.classes || []),
           ...(els.ids || []),
-          ...attributes,
         ];
       },
-      safelist: []
+      safelist: [
+        ...attributes,
+        ...highlightJs,
+      ]
     }),
   ],
 };

--- a/config/postcss.config.js
+++ b/config/postcss.config.js
@@ -1,19 +1,27 @@
 const autoprefixer = require('autoprefixer');
 const purgecss = require('@fullhuman/postcss-purgecss');
 
-const attributes = [
+const safelist = [
+  // DOM attributes
   'data-dark-mode',
   'completed',
   'selected',
   'disappear',
   'open',
+  'announcement',
   'data-global-alert',
-  'id'
-];
-
-const highlightJs = [
+  'id',
+  // Highlight JS
   'hljs',
-  /^hljs-.*/
+  /^hljs-.*/,
+  // Search bar
+  'suggestions',
+  /suggestion__.*/,
+  // Mermaid diagrams
+  'language-mermaid',
+  // Scroll-lock
+  'sidebar-default',
+  'sidebar-scroll',
 ];
 
 module.exports = {
@@ -29,10 +37,7 @@ module.exports = {
           ...(els.ids || []),
         ];
       },
-      safelist: [
-        ...attributes,
-        ...highlightJs,
-      ]
+      safelist,
     }),
   ],
 };


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Added any JS injected css selectors manually to the purgeCSS safelist, since hugo cannot automatically detect them
- Updated the Mermaid css config

**- How I did it**

Local changes

**- How to verify it**

See each of the JS files in doks for css selectors, compare to my list

**- Description for the changelog**
Update PurgeCSS safelist to protect JS injected css selectors
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->