### PR TITLE
Fix: Nav width for codelab template

### DIFF
--- a/assets/scss/codelab/_main.scss
+++ b/assets/scss/codelab/_main.scss
@@ -6,6 +6,7 @@ nav.doks-subnavbar, [data-dark-mode] nav.doks-subnavbar {
   margin: 1rem auto;
   display: grid;
   grid-template-areas: 'exit timer' 'menu title' 'menu body';
+  grid-template-columns: auto 1fr;
   width: 100%;
   height: 100%;
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

closes #53 

**- What I did**

Updated codelab CSS to fix oversizing of nav when content does not fill the screen

**- How I did it**

Local changes

**- How to verify it**
Before
![image](https://user-images.githubusercontent.com/33691921/173659719-77db5053-ea6e-41f9-b479-c8cf1897137b.png)
After
![image](https://user-images.githubusercontent.com/33691921/173659661-7a19af77-6d94-4a18-b411-c5eb78ed04d7.png)

**- Description for the changelog**
Fix: Nav width for codelab template
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->