### PR TITLE
fix: `cram.md` shortcode bug

### DIFF
--- a/content/docs/reference/cram.md
+++ b/content/docs/reference/cram.md
@@ -50,7 +50,7 @@ rel="canonical"
 target="\_blank"
 href="https://github.com/atsign-foundation/at_protocol/blob/trunk/specification/at_protocol_specification.md#the-cram-verb"
 
-> }}
+>}}
 
     here{{< /a >}}.
 


### PR DESCRIPTION
**- What I did**
Fix `cram.md` shortcode bug (giving @L1AMcB troubles running the dev site on his own machine)

**- How I did it**
See changes

**- How to verify it**
No errors on my machine
![image](https://user-images.githubusercontent.com/79019866/177622401-caa212bb-eaed-427a-bc9c-5df577c8239e.png)