### PR TITLE
docs: fix `notify verb` protocol regex, add `notify:list verb`

### DIFF
--- a/content/docs/reference/notification.md
+++ b/content/docs/reference/notification.md
@@ -3,7 +3,7 @@ layout: single
 
 title: "Notification" # The title (ON THE PAGE)
 lead: | # The lead below the title (ON THE PAGE)
-  Definition of Notification, the notify verb, and Monitor
+  atPlatform & atProtocol Information on Notification
 
 description:
   | # SEO Description of the page (Shows in google and atsign.dev search)
@@ -16,19 +16,32 @@ weight: 211 # For single pages, lower is first.
 
 ## atPlatform
 
-Notification enables developers to **notify** another atSign of some data event. It is used to send data from one atSign's secondary server to another atSign's secondary server.
+### Notification
+
+Notification enables developers to **notify** another atSign of some data event. It is used to **notify** another atSign that data from your secondary server was modified (updated or deleted). Some example notifications include: the key's value updated, the key was deleted, the key's metadata changed, and more.
 
 The atPlatform takes care of all of the heavy lifting with encryption, verb building, transmission, etc,.
 
 Read more [here](https://blog.atsign.dev/part-1-the-notify-verb-cko97bv8f00l5gws13umb0nvz).
 
+### Monitor
+Monitor uses notifications.
+
+Monitor is used to receive notifications from the other secondary server.
+
+Read more {{< a href="https://github.com/atsign-foundation/at_client_sdk/blob/trunk/at_client/lib/src/manager/monitor.dart" target="_blank" rel="canonical" >}}here{{</ a >}}.
+
 ## atProtocol
+
+### notify verb
 
 The notify verb enables you to notify the atsign user of some data event.
 
 The following is the regex for the `notify` verb.
 
-`notify:((?<operation>update|delete):)?(ttl:(?<ttl>\d+):)?(ttb:(?<ttb>\d+):)?(ttr:(?<ttr>(-)?\d+):)?(ccd:(?<ccd>true|false):)?(@(?<forAtSign>[^@:\s]-)):(?<atKey>[^:]((?!:{2})[^@])+)@(?<atSign>[^@:\s]+)(:(?<value>.+))?`
+```
+notify:((?<operation>update|delete):)?(ttl:(?<ttl>\d+):)?(ttb:(?<ttb>\d+):)?(ttr:(?<ttr>(-)?\d+):)?(ccd:(?<ccd>true|false):)?(@(?<forAtSign>[^@:\s]-)):(?<atKey>[^:]((?!:{2})[^@])+)@(?<atSign>[^@:\s]+)(:(?<value>.+))?
+```
 
 | Regex Snippet                                                       | Explanation, [argument details], (example)                                                                                                                                                                             |
 | ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -37,45 +50,66 @@ The following is the regex for the `notify` verb.
 | `(ttb:(?<ttb>\d+):)?`                                               | TTB (time to birth), [integer, 1 or more digits, optional argument]                                                                                                                                                    |
 | `(ttr:(?<ttr>(-)?\d+):)?`                                           | TTR (time to refresh), [integer, 1 or more digits, can be negative, optional argument], (e.g.: 86400 will refresh once a day)                                                                                          |
 | `(ccd:(?<ccd>true\|false):)?`                                       | CCD (casecade delete), [boolean, true\|false, optional argument], (e.g.: if the sender deletes their original key and ccd is true, the cached key gets deleted on both the sender's server and the recipient's server) |
-| `(@(?<forAtSign>[^@:\s]-))`                                         | The atSign the notification is for, [string, negate @ character, required argument]                                                                                                                                    |
-| `(?<atKey>[^:]((?!:{2})[^@])+)@(?<atSign>[^@:\s]+)(:(?<value>.+))?` | AtKey details, see below, [optional], (`signing_publickey@alice`)                                                                                                                                                      |
+
+Following the metadata for creating the notification, next, we mention the AtKey the notification pertains to.
 
 | AtKey Regex Snippet                  | Explanation, [argument details], (example)                                         |
 | ------------------------------------ | ---------------------------------------------------------------------------------- |
-| `(?<atKey>[^:]((?!:{2})[^@])+)`      | AtKey name, [], (e.g. 'signing_publickey')                                         |
+| `(@(?<forAtSign>[^@:\s]-))`                                         | The atSign the notification is for, [string, required argument], (`@alice`)                                                                                                                                    |
+| `(?<atKey>[^:]((?!:{2})[^@])+)`      | AtKey name, [string, required argument], (e.g. 'signing_publickey')                                         |
 | `@`                                  | at separator                                                                       |
-| `(?<atSign>[^@:\s]+)(:(?<value>.+))` | namespace atSign that key belongs to, [string, negate @ character], (e.g. 'alice') |
+| `(?<atSign>[^@:\s]+)(:(?<value>.+))` | sharedBy/creator atSign, [string], (e.g. 'bob') |
+
+Example use of the `notify` verb:
+
+```
+notify:update:@farinataanxious:test@33thesad
+```
 
 Response:
 
-If the user is the owner, returns a list of received notifications. If a user is pol authenticated user, returns a list of sent notifications.
+If the notification was successfully sent, then the id of the notification is returned.
 
-`data:[{"id":"0e5e9e89-c9cb-423b-8972-8c5487215990","from":"@alice","to":"@bob","key":"@bob:phone@alice","value":12345,"operation":"update","epochMillis":1603714122636}]`
+```
+data:0ce0d150-52bf-4f09-a473-5c64777b1c53
+```
 
 Read more {{< a href="https://github.com/atsign-foundation/at_protocol/blob/trunk/specification/at_protocol_specification.md#the-sync-verb" target="_blank" rel="canonical" >}}here{{</ a >}}.
 
-## Monitor
+### notify:list verb
 
-### atPlatform
+Notify list returns a list of notifications
 
-Monitor uses notifications.
+Regex
 
-Monitor is used to receive notifications from the other secondary server.
+```
+notify:(list (?<regex>.-)|list$)
+```
 
-Read more {{< a href="https://github.com/atsign-foundation/at_client_sdk/blob/trunk/at_client/lib/src/manager/monitor.dart" target="_blank" rel="canonical" >}}here{{</ a >}}.
+Response:
 
-### atProtocol
+If the user is the owner, returns a list of received notifications. if a user is pol authenticated user, return a list of sent notifications
+
+```
+data:[{"id":"0e5e9e89-c9cb-423b-8972-8c5487215990","from":"@alice","to":"@bob","key":"@bob:phone@alice","value":12345,"operation":"update","epochMillis":1603714122636}]
+```
+
+### monitor verb
 
 The monitor verb streams received notifications.
 
 The following is the regex
-`^monitor$|^monitor ?(?<regex>.-)?)$`
+```
+^monitor$|^monitor ?(?<regex>.-)?)$
+```
 
 Response:
 
 Returns a stream of notifications
 
-`@alice@monitor notification: {"id":"773e226d-dac2-4269-b1ee-64d7ce93a42f","from":"@bob","to":"@alice","key":"@alice:phone@bob","value":null,"operation":"update","epochMillis":1603714720965}`
+```
+@alice@monitor notification: {"id":"773e226d-dac2-4269-b1ee-64d7ce93a42f","from":"@bob","to":"@alice","key":"@alice:phone@bob","value":null,"operation":"update","epochMillis":1603714720965}
+```
 
-Read more here.
+Read more 
 {{< a href="https://github.com/atsign-foundation/at_protocol/blob/trunk/specification/at_protocol_specification.md" target="_blank" rel="canonical" >}}here{{</ a >}}.


### PR DESCRIPTION
**- What I did**
- added atPlatform definitions for Notification and Monitor
- fixed `notify verb` protocol regex (was incorrect before)
- add `notify:list verb` protocol
- changed single ` to triple ```