### PR TITLE
fix: hide nav button when lg breakpoint

### DIFF
--- a/hugo_stats.json
+++ b/hugo_stats.json
@@ -260,7 +260,6 @@
       "toggle-dark",
       "toggle-light",
       "tutorials",
-      "w-100",
       "w-25",
       "w-50",
       "wrap"

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -96,7 +96,7 @@
     </button>
     {{ end -}}
 
-    <button class="btn btn-menu order-md-1" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasDoks" aria-controls="offcanvasDoks" aria-label="Open main menu">
+    <button class="btn btn-menu order-md-1 d-lg-none" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasDoks" aria-controls="offcanvasDoks" aria-label="Open main menu">
       <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-menu"><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
     </button>
   </nav>


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added back a missing css class to hide the menu button when the screen is large enough to show the menu to the left side.
**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: hide nav button when lg breakpoint
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->