### PR TITLE
refactor: add `at_onboarding_cli` to sshnp tutorial

### DIFF
--- a/content/docs/tutorials/sshnp/1-prerequisites/index.md
+++ b/content/docs/tutorials/sshnp/1-prerequisites/index.md
@@ -22,5 +22,10 @@ Demo video:
 Instructions:
 
 1. Prepare two atSigns and ensure you have both of their `.atKeys` files. If you've done this, skip to step 3.
-2. If you don't have two atSigns (free or paid), go to [atsign.com](https://atsign.com). Once you've purchased two atSigns be sure to activate them on the dashboard by pressing the "Click to activate" button on each atSign dropdown. Then you will have to onboard these atSigns by downloading one of our apps and onboard the atSign via our [at_onboarding_flutter widget](https://pub.dev/packages/at_onboarding_flutter). This will generate your .atKeys file for you. Save this `.atKeys` file to the machine you are working on. One of these atSigns wil be the "manager" atSign working on the client-side and the other atSign will be the "device" atSign working in the remote device.
+2. If you don't have two atSigns (free or paid), go to [atsign.com](https://atsign.com). Once you've obtained two atSigns be sure to activate them on the dashboard by pressing the "Click to activate" button on each atSign dropdown. Then you will have to onboard these atSigns and generate your .atKeys files. There are two ways you can do this.
+
+One, you can download one of our apps (like [atmospherePro](https://atsign.com/apps/atmospherepro/)) and onboard the atSign via the [at_onboarding_flutter widget](https://pub.dev/packages/at_onboarding_flutter) built into the app. This will generate your .atKeys file for you. Save this `.atKeys` file to the machine you are working on. One of these atSigns wil be the "manager" atSign working on the client-side and the other atSign will be the "device" atSign working in the remote device. 
+
+Two, you can also use the [at_onboarding_cli](https://github.com/atsign-foundation/at_libraries/tree/trunk/at_onboarding_cli) to generate your keys through terminal.
+
 3. Download the binaries [here](https://github.com/atsign-foundation/sshnoports/releases). Ssh! No ports comes with two binary files. One binary (sshnpd) is the daemon that runs on the remote linux host/device, while the other binary (sshnp) runs on the client that is connecting to the device via ssh. *It is also possible to run the source code via `dart run`.


### PR DESCRIPTION
Quickly mention the `at_onboarding_cli` in the sshnp tutorial documentation.