### PR TITLE
docs: improve grammar in sdk/flutter/introduction/ and sdk/flutter/at_client_preference/

### DIFF
--- a/content/docs/sdk/flutter/at_client_preference.md
+++ b/content/docs/sdk/flutter/at_client_preference.md
@@ -25,12 +25,12 @@ AtClientPreference is used to configure the preferences of an atPlatform applica
 | rootDomain                | Domain of the root server. Defaults to root.atsign.com                                                            |
 | rootPort                  | Port of the root server. Defaults to 64                                                                           |
 | syncIntervalMins          | Frequency of sync tasks to run in minutes. Defaults to 10 minutes.                                                |
-| outboundConnectionTimeout | Idle time in milliseconds of connection to secondary server. Default to 10 minutes.                               |
+| outboundConnectionTimeout | Idle time in milliseconds of connection to secondary server. Defaults to 10 minutes.                              |
 | maxDataSize               | Maximum data size a secondary can store. Temporary solution. Have to fetch this from the server using stats verb. |
 | downloadPath              | Default path to download stream files                                                                             |
-| syncRegex                 | regex to perform sync                                                                                             |
+| syncRegex                 | Regex to perform sync                                                                                             |
 | syncBatchSize             | Number of keys to batch for sync to secondary server                                                              |
-| syncPageLimit             | The number of keys to pull from cloud secondary to local secondary in a single call.                              |
+| syncPageLimit             | Number of keys to pull from cloud secondary to local secondary in a single call.                                  |
 
 For Local device paths we recommend the path_provider package.
 

--- a/content/docs/sdk/flutter/introduction.md
+++ b/content/docs/sdk/flutter/introduction.md
@@ -19,7 +19,7 @@ If you haven't already, we recommend you head to [Get Started Flutter Developmen
 
 The following is covered in this codelab:
 
-- **AtClientManager** - an object with various services such as Client, NotificationService, and SyncService.
+- **AtClientManager** - object with various services such as Client, NotificationService, and SyncService.
 - **AtClientPreference** - object used to configure preferences in your atPlatform application such as the namespace, storage path for the hive database, or maximum data size.
 - **Onboarding** - process of activating an atSign and/or authenticating the atsign into its secondary server.
 - **Key Basics** - learn how keys are stored in the secondary server and what key metadata is.
@@ -30,7 +30,7 @@ Our atPlatform has a lot to offer for Dart/Flutter developers.
 
 - [at_widgets](https://github.com/atsign-foundation/at_widgets) - Flutter widgets for using various aspects of the atPlatform
 - [at_demos](https://github.com/atsign-foundation/at_demos) - collection of demo applications to help you on your atPlatform journey
-- [at_app](https://github.com/atsign-foundation/at_app) - command-line utility for developing app developers
+- [at_app](https://github.com/atsign-foundation/at_app) - command-line utility for atPlatform developers
 - [at_tools](https://github.com/atsign-foundation/at_tools) - other atPlatform tools (at_cli, at_cram, at_pkam,...)
 
 Explore our GitHub page [atsign-foundation](https://github.com/atsign-foundation) to see more of our amazing projects and tools.


### PR DESCRIPTION
**- What I did**
For consistent style with the rest of the document, changed "an object" to "object".

Replaced "for developing app developers", with clearer phrase "for atPlatform developers".

For issue:  Docs Grammar and Typos #158

**- How I did it**
Edited the markdown file

**- How to verify it**
Changes will appear at https://docs.atsign.com/sdk/flutter/introduction/

**- Description for the changelog**
improve grammar in sdk/flutter/introduction/
