### PR TITLE
fix: unlinked text-email

### DIFF
--- a/content/docs/sdk/flutter/onboarding.md
+++ b/content/docs/sdk/flutter/onboarding.md
@@ -16,7 +16,7 @@ The atPlatform uses secret keys for authenticating an atSign as a cryptographica
 ## Usage
 
 Before using the onboarding widget, ensure that your [AtClientPreference](https://docs.google.com/document/d/14PZ-FHV9djBJL1RR8G8aYd6qxiWErBJEvRW9hD0pfNQ/edit#heading=h.yept27gyvv8g) is properly assigned.
-If you need an appAPIKey please email us at: support@atsign.com
+If you need an appAPIKey please email us at: [support@atsign.com](mailto://support@atsign.com)
 
 ```
 Onboarding(

--- a/content/docs/sdk/flutter/onboarding.md
+++ b/content/docs/sdk/flutter/onboarding.md
@@ -16,7 +16,7 @@ The atPlatform uses secret keys for authenticating an atSign as a cryptographica
 ## Usage
 
 Before using the onboarding widget, ensure that your [AtClientPreference](https://docs.google.com/document/d/14PZ-FHV9djBJL1RR8G8aYd6qxiWErBJEvRW9hD0pfNQ/edit#heading=h.yept27gyvv8g) is properly assigned.
-If you need an appAPIKey please email us at.
+If you need an appAPIKey please email us at: support@atsign.com
 
 ```
 Onboarding(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

⚒️Fixes #184 

**- What I did**
Added the email: [support@atsign.com](mailto:support@atsign.com) on the onboarding page of flutter.

**- How I did it**
Added a `mailto:` hyperlink at the appropriate position

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fixed the unlinked text by redirecting to the default mailing app of the user.