### PR TITLE
feat: line breaks after images in atmospherePro contributing codelab

### DIFF
--- a/content/docs/contribute/atmosphere-pro/2-git-clone/index.md
+++ b/content/docs/contribute/atmosphere-pro/2-git-clone/index.md
@@ -16,14 +16,17 @@ Now, it is time to fork the atmospher
 2. Head over to [atmosphere_pro](https://github.com/atsign-foundation/atmosphere_pro) and click "Fork".
 
 {{< image type="page" src="fork.png" >}}
+{{< br >}}
 
 3. You should be given prompted to create a new repository on your account. Change these settings to your needs. Change the repository name, description, or copy all of the branches if you'd like. We recommend the default settings.
 
 {{< image type="page" src="repo.png" >}}
+{{< br >}}
 
 4. Now that you have the repository on your own personal GitHub account, you can get the GitHub url by clicking on "Code," clicking "HTTPS," then copy the url.
 
 {{< image type="page" src="https.png" >}}
+{{< br >}}
 
 5. On your local machine, `cd` into the directory where you want to clone the repository. This can be done either on your terminal or on the terminal in your code editor.
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- I added newline after each image**

**- I have inserted {{< br >}} after the image source in the index.md file along with a image of the file after editing**

**- added line break after each image**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
![h1](https://user-images.githubusercontent.com/77684403/194706317-f5fd25ab-c78c-42b9-877d-52d24a214fa6.png)

closes #163 