### PR TITLE
feat: SEO descriptions in `content/docs/reference/`

### DIFF
--- a/content/docs/reference/atsign.md
+++ b/content/docs/reference/atsign.md
@@ -7,7 +7,7 @@ lead: | # The lead below the title (ON THE PAGE)
 
 description:
   | # SEO Description of the page (Shows in google and atsign.dev search)
-  Learn about what an atSign is in the atPlatform
+  Learn about what an atSign is in the atPlatform: An atSign is a handle (e.g. @alice) that functions as your digital identity. It uses end-to-end encryption to ensure that your data is 100% owned and controlled by you.
 
 draft: false # Change this to "true" to hide the page
 toc: true # Change this to "true" to show the table of contents

--- a/content/docs/reference/cram.md
+++ b/content/docs/reference/cram.md
@@ -7,7 +7,7 @@ lead: | # The lead below the title (ON THE PAGE)
 
 description:
   | # SEO Description of the page (Shows in google and atsign.dev search)
-  Definition of CRAM (challenge response authentication method)
+  Definition of CRAM (challenge response authentication method): CRAM stands for challenge response authentication mechanism. It is an algorithm/mechanism used in cryptography commonly used for authentication in protocols.
 
 draft: false # Change this to "true" to hide the page
 toc: true # Change this to "true" to show the table of contents

--- a/content/docs/reference/encryption.md
+++ b/content/docs/reference/encryption.md
@@ -11,7 +11,7 @@ description:
 
 ## Video
 
-Hate reading? Watch this [video](https://www.youtube.com/watch?v=A12jdKPa4WE) instead!
+Not a fan of reading? Watch this [video](https://www.youtube.com/watch?v=A12jdKPa4WE) instead!
 
 {{< youtube src="https://www.youtube.com/embed/A12jdKPa4WE" >}}
 

--- a/content/docs/reference/encryption.md
+++ b/content/docs/reference/encryption.md
@@ -7,7 +7,32 @@ lead: | # The lead below the title (ON THE PAGE)
 
 description:
   | # SEO Description of the page (Shows in google and atsign.dev search)
-  Definition of the term encryption
+  Encryption is a means of achieving privacy. It is a part of cryptography. The goal of encryption is that assuming that an unwanted third party is eavesdropping on an insecure channel, said person would not be able to comprehend the transmitted information. Decryption is the process of converted encrypted information into a comprehensible format. Encryption and Decryption algorithms are known as ciphers. Encryption uses a key which is a set of values that the cipher, as an algorithm, will operate on. Encryption and Decryption go back a long way with one of the most well known ciphers being the [Caesar Cipher](https://en.wikipedia.org/wiki/Caesar_cipher)
+
+## Video
+
+Hate reading? Watch this [video](https://www.youtube.com/watch?v=A12jdKPa4WE) instead!
+
+{{< youtube src="https://www.youtube.com/embed/A12jdKPa4WE" >}}
+
+## atPlatform
+
+The atPlatform implements end-to-end encryption that is best illustrated with the following example: @alice wishes to share her phone number with her friend @bob. To do this, @alice, who is on her own device, prompts her own secondary server to direct phone @alice at her friend @bob's secondary server. From here, a shared key is generated for @bob (@bob:shared_key@alice).
+
+This shared key uses the same encryption process as the Symmetric Key Encryption, which is called AES (Advanced Encryption Standard) and involves three block ciphers: AES-128, AES-192 and AES-256.
+
+The atProtocol specifically uses AES-256 for Data Encryption Keys.
+
+The RSA (Rivest-Shamir-Adleman) encryption algorithm is then used to encrypt the shared key from the above example with @bob's public key. The atProtocol specifically utilizes RSA 2048. Note, that because the RSA algorithm is an Asymmetric Key Encryption method, a public and private key are generated.
+
+If you want to read more about Encryption and how it works on the atPlatform check this [Medium](https://atsigncompany.medium.com/data-encryption-caching-with-the-protocol-debe9efc0f49) article!
+
+## Related Resources
+
+{{< card/breadcrumb link="/reference/public_private_keys/" first="Public and Private Keys" >}}
+{{< card/breadcrumb link="/reference/self_encryption_key/" first="Self-Encryption Key" >}}
+{{< card/breadcrumb link="/reference/privacy/" first="Privacy" >}}
+
 
 draft: false # Change this to "true" to hide the page
 toc: true # Change this to "true" to show the table of contents

--- a/content/docs/reference/namespace.md
+++ b/content/docs/reference/namespace.md
@@ -7,7 +7,9 @@ lead: | # The lead below the title (ON THE PAGE)
 
 description:
   | # SEO Description of the page (Shows in google and atsign.dev search)
-  Definition of Namespace in the atPlatform
+  Definition of Namespace in the atPlatform: a unique container to place
+data in. More in the context of the apps, namespaces are just atSigns associated with each app so a secondary server can be aware of which
+data belongs to who. See an example below.
 
 draft: false # Change this to "true" to hide the page
 toc: true # Change this to "true" to show the table of contents

--- a/content/docs/reference/namespace.md
+++ b/content/docs/reference/namespace.md
@@ -7,9 +7,7 @@ lead: | # The lead below the title (ON THE PAGE)
 
 description:
   | # SEO Description of the page (Shows in google and atsign.dev search)
-  Definition of Namespace in the atPlatform: a unique container to place
-data in. More in the context of the apps, namespaces are just atSigns associated with each app so a secondary server can be aware of which
-data belongs to who. See an example below.
+  Definition of Namespace in the atPlatform - a unique container to place data in. More in the context of the apps, namespaces are just atSigns associated with each app so a secondary server can be aware of which data belongs to whom.
 
 draft: false # Change this to "true" to hide the page
 toc: true # Change this to "true" to show the table of contents

--- a/content/docs/reference/notification.md
+++ b/content/docs/reference/notification.md
@@ -7,7 +7,7 @@ lead: | # The lead below the title (ON THE PAGE)
 
 description:
   | # SEO Description of the page (Shows in google and atsign.dev search)
-  Definition of Notification in the atPlatform, the notify verb in the atProtocol, and Definition of Monitor in the atPlatform
+  Definition of Notification in the atPlatform: Notification enables developers to notify another atSign of some data event. It is used to notify another atSign that data from your secondary server was modified (updated or deleted). Some example notifications include: the key's value is updated, the key is deleted, the key's metadata changed, and more. The notify verb in the atProtocol (which enables you to notify the atSign user of some data event.), and Definition of Monitor in the atPlatform: The monitor is used to receive notifications from the other secondary server.
 
 draft: false # Change this to "true" to hide the page
 toc: true # Change this to "true" to show the table of contents

--- a/content/docs/reference/pkam.md
+++ b/content/docs/reference/pkam.md
@@ -7,7 +7,8 @@ lead: | # The lead below the title (ON THE PAGE)
 
 description:
   | # SEO Description of the page (Shows in google and atsign.dev search)
-  Definition of PKAM (public key authentication mechanism)
+  Definition of PKAM (public key authentication mechanism, a mechanism for encrypting/decrypting data between two parties). The PKAM public key is given out to other clients who want to send data to you. The data they send to you is encrypted using your public key
+and is decrypted using your private key.
 
 draft: false # Change this to "true" to hide the page
 toc: true # Change this to "true" to show the table of contents

--- a/content/docs/reference/pkam.md
+++ b/content/docs/reference/pkam.md
@@ -7,8 +7,7 @@ lead: | # The lead below the title (ON THE PAGE)
 
 description:
   | # SEO Description of the page (Shows in google and atsign.dev search)
-  Definition of PKAM (public key authentication mechanism, a mechanism for encrypting/decrypting data between two parties). The PKAM public key is given out to other clients who want to send data to you. The data they send to you is encrypted using your public key
-and is decrypted using your private key.
+  Definition of PKAM (public key authentication mechanism, a mechanism for encrypting/decrypting data between two parties). The PKAM public key is given out to other clients who want to send data to you. The data they send to you is encrypted using your public key and is decrypted using your private key.
 
 draft: false # Change this to "true" to hide the page
 toc: true # Change this to "true" to show the table of contents

--- a/content/docs/reference/polymorphism.md
+++ b/content/docs/reference/polymorphism.md
@@ -7,7 +7,7 @@ lead: | # The lead below the title (ON THE PAGE)
 
 description:
   | # SEO Description of the page (Shows in google and atsign.dev search)
-  Definition of Polymorphism
+  Definition of Polymorphism: the ability to share different data depending on the context of who’s asking. atPlatform applications enable you to set up multiple personas for different areas of your life. When you share data with someone else, the value of that data may be different depending on the person receiving that data. This is true for both sides, you may ask for data from different sources and get a different answer for each one.
 
 draft: false # Change this to "true" to hide the page
 toc: true # Change this to "true" to show the table of contents

--- a/content/docs/reference/pricing-and-costs.md
+++ b/content/docs/reference/pricing-and-costs.md
@@ -20,7 +20,7 @@ Since the atPlatform is fully open-sourced and everyone can contribute, there is
 
 ## Video
 
-Hate reading? Watch this [video](https://www.youtube.com/watch?v=npUMux-uS3Y) instead!
+Not a fan of reading? Watch this [video](https://www.youtube.com/watch?v=npUMux-uS3Y) instead!
 
 {{< youtube src="https://www.youtube.com/embed/npUMux-uS3Y" >}}
 

--- a/content/docs/reference/pricing-and-costs.md
+++ b/content/docs/reference/pricing-and-costs.md
@@ -7,7 +7,7 @@ lead: | # The lead below the title (ON THE PAGE)
 
 description:
   | # SEO Description of the page (Shows in google and atsign.dev search)
-  Reference on the pricing and costs on atSigns
+  Reference on the pricing and costs on atSigns: Since the atPlatform is fully open-sourced , there is no cost for developers! **Atsign** generates revenue is by using our special identifier which is known as an atSign. An atSign can come in many flavors with corresponding prices ranging from free, $10, $100, $1000, $5000.For each paid atSign you own, there is a $10 annual renewal fee. This fee does not apply to the free atSigns. What makes atSigns so awesome is that if your app is the first one someone pairs an atSign with, after buying their atSign, we pay you commission on that. Yep, you don't pay us, we pay you.
 
 draft: false # Change this to "true" to hide the page
 toc: true # Change this to "true" to show the table of contents

--- a/content/docs/reference/privacy.md
+++ b/content/docs/reference/privacy.md
@@ -23,6 +23,6 @@ We live in an age of information. Information is an asset that has a similar val
 
 ## Video
 
-Hate reading? Watch this [video](https://www.youtube.com/watch?v=F1txoXUPeSA) instead!
+Not a fan of reading? Watch this [video](https://www.youtube.com/watch?v=F1txoXUPeSA) instead!
 
 {{< youtube src="https://www.youtube.com/embed/F1txoXUPeSA" >}}

--- a/content/docs/reference/privacy.md
+++ b/content/docs/reference/privacy.md
@@ -5,8 +5,7 @@ title: 'Privacy' # The title (ON THE PAGE)
 lead: | # The lead below the title (ON THE PAGE)
   Protecting your most valuable asset
 description: | # SEO Description of the page (Shows in google and atsign.dev search)
-    Definition of the term privacy
-
+    Definition of the term privacy:  InformationAs as an asset, must be secured from potential attacks or unauthorized access. There are several security goals that must be considered like Confidentiality, Integrity, Availability, Authentication/Liveness and Non-repudiation.
 draft: false # Change this to "true" to hide the page
 toc: true # Change this to "true" to show the table of contents
 weight: 203 # For single pages, lower is first.

--- a/content/docs/reference/public-private-keys/index.md
+++ b/content/docs/reference/public-private-keys/index.md
@@ -7,7 +7,7 @@ lead: | # The lead below the title (ON THE PAGE)
 
 description:
   | # SEO Description of the page (Shows in google and atsign.dev search)
-  Definition of public and private keys
+  Definition of public key(distributed to the trusted masses), self key(which cannot be looked up any atSign holder other than creator) ,shared key(an only be looked up by an atSign holder with whom the data has been shared), cashed key(a key that was originally created by another atSign owner but is now cached on the Secondary Server of another person's atSign as they were given permission to cache it) and private keys(used in asymmetric key cryptography).
 
 draft: false # Change this to "true" to hide the page
 toc: true # Change this to "true" to show the table of contents

--- a/content/docs/reference/self-encryption-key.md
+++ b/content/docs/reference/self-encryption-key.md
@@ -7,7 +7,7 @@ lead: | # The lead below the title (ON THE PAGE)
 
 description:
   | # SEO Description of the page (Shows in google and atsign.dev search)
-  Definition of Self-Encryption Key at Atsign
+  Definition of Self-Encryption Key at Atsign: an AES symmetric key that you own for encrypting data for yourself.In the atPlatform, the self-encryption key is used to encrypt data that is stored in your own secondary server. It is crucial that this key is kept secret and owned only by you so that third parties like Atsign cannot see your data.
 
 draft: false # Change this to "true" to hide the page
 toc: true # Change this to "true" to show the table of contents

--- a/content/docs/reference/synchronization.md
+++ b/content/docs/reference/synchronization.md
@@ -7,7 +7,7 @@ lead: | # The lead below the title (ON THE PAGE)
 
 description:
   | # SEO Description of the page (Shows in google and atsign.dev search)
-  Definition of Synchronization in the atPlatform
+  Definition of Synchronization in the atPlatform: encryption of your data with atProtocol, with your self encryption key and stored on your device. Periodically, this data is copied securely over to a dedicated cloud server which only you can decrypt and read since you are the only one who owns the private key. No one else, including **Atsign** can read your data.
 
 draft: false # Change this to "true" to hide the page
 toc: true # Change this to "true" to show the table of contents


### PR DESCRIPTION
Adding better SEO descryption for the files
<!-- fixes #186 partially -->
@JeremyTubongbanua Please review and provide some sugestions, accordingly I will add commits for the other files too in this same pr.

<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
SEO description of pages at content/docs/reference/

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Updating SEO description of pages (at content/docs/reference/) for better google search reasults