### PR TITLE
Added break words

### DIFF
--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -112,7 +112,7 @@
 
     <form class="doks-search position-relative flex-grow-1 me-auto">
       <input id="search" class="form-control is-search" type="search" placeholder="Search docs..." aria-label="Search docs..." autocomplete="off">
-      <div id="suggestions" class="shadow bg-white rounded d-none"></div>
+      <div id="suggestions" class="shadow bg-white rounded d-none" style="word-break: break-word;"></div>
     </form>
 
     {{ if eq .Site.Params.options.docsVersioning true -}}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
close #199 
Resolved the searches UI which was often crossing the designated area due to a single word having size more than the provided.
**- How I did it**
Added word wrap to the search UI.
**- How to verify it**
1. First I Clicked on the Search bar
2. Then I typed get
3. And then saw that the search suggestion UI is not proper
**- Description for the changelog**
Updated search UI so it does not overlaps the border.
![image](https://user-images.githubusercontent.com/76838551/195930135-948798d4-006b-4b7c-b55f-92ceca292082.png)

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->