### PR TITLE
docs: update repo name in dev environment setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,22 +34,22 @@ describe.
 
 To prepare your dedicated GitHub repository:
 
-1. Fork in GitHub https://github.com/atsign-foundation/atsign.dev-3.0
-2. Clone *your forked repository* (e.g., `git clone git@github.com:yourname/atsign.dev-3.0`)
+1. Fork in GitHub https://github.com/atsign-foundation/docs.atsign.com
+2. Clone *your forked repository* (e.g., `git clone git@github.com:yourname/docs.atsign.com`)
 3. Set your remotes as follows:
 
    ```sh
-   cd atsign.dev-3.0
-   git remote add upstream git@github.com:atsign-foundation/atsign.dev-3.0.git
+   cd docs.atsign.com
+   git remote add upstream git@github.com:atsign-foundation/docs.atsign.com.git
    git remote set-url upstream --push DISABLED
    ```
 
    Running `git remote -v` should give something similar to:
 
    ```text
-   origin  git@github.com:yourname/atsign.dev-3.0.git (fetch)
-   origin  git@github.com:yourname/atsign.dev-3.0.git (push)
-   upstream        git@github.com:atsign-foundation/atsign.dev-3.0.git (fetch)
+   origin  git@github.com:yourname/docs.atsign.com.git (fetch)
+   origin  git@github.com:yourname/docs.atsign.com.git (push)
+   upstream        git@github.com:atsign-foundation/docs.atsign.com.git (fetch)
    upstream        DISABLED (push)
    ```
 


### PR DESCRIPTION
**- What I did**
Update the repo name in the development environment setup instructions in CONTRIBUTING.md. It seems like the repo name changed from `atsign.dev-3.0` to `docs.atsign.com` at some point, so the instructions were a bit surprising.

**- How I did it**
In the development environment setup instructions in CONTRIBUTING.md, replaced the string `atsign.dev-3.0` with `docs.atsign.com`. I used the modified commands to set up this repo locally and they worked.

**- How to verify it**
Clone the repo and use the new commands to set it up locally.

**- Description for the changelog**
Update repo name in dev environment setup instructions in CONTRIBUTING.md