### PR TITLE
fix: Search UI broken

### DIFF
--- a/assets/scss/common/_overrides.scss
+++ b/assets/scss/common/_overrides.scss
@@ -120,3 +120,10 @@ i.fa-solid {
   color: $highlight;
 }
 
+span.suggestion__title {
+    display: inline-block !important;
+    overflow: hidden;
+    text-align: left;
+    text-overflow: ellipsis;
+}
+


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed the broken search UI by applying ellipses to the overflowing text

**- How I did it**
Added css rules for the suggestion__title class, to add ellipses to overflowing text.

**- How to verify it**
1. Click on the Search bar.
2. Type get
3. Observe the fixed UI
<img width="627" alt="image" src="https://user-images.githubusercontent.com/24457377/197339493-f010cd26-112f-495a-9738-2f5573f64c2e.png">

**- Description for the changelog**
fixes #199 
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->