### PR TITLE
enhancement: remove strikethrough styling from visited links in tutorial nav pane.

### DIFF
--- a/assets/scss/codelab/_main.scss
+++ b/assets/scss/codelab/_main.scss
@@ -69,6 +69,10 @@ nav.doks-subnavbar, [data-dark-mode] nav.doks-subnavbar {
         // text-decoration: line-through;
         font-style: italic;
       }
+      li[completed]::after {
+        // text-decoration: line-through;
+        content: "✔";
+      }
 
       li[selected], li[selected] a {
         color: $primary;

--- a/assets/scss/codelab/_main.scss
+++ b/assets/scss/codelab/_main.scss
@@ -66,12 +66,13 @@ nav.doks-subnavbar, [data-dark-mode] nav.doks-subnavbar {
       }
 
       li[completed] {
-        // text-decoration: line-through;
         font-style: italic;
       }
       li[completed]::after {
-        // text-decoration: line-through;
-        content: "✔";
+        content: "✓";
+        font-style: normal;
+        color: #f05e3e;
+        font-weight: 900;
       }
 
       li[selected], li[selected] a {

--- a/assets/scss/codelab/_main.scss
+++ b/assets/scss/codelab/_main.scss
@@ -66,7 +66,8 @@ nav.doks-subnavbar, [data-dark-mode] nav.doks-subnavbar {
       }
 
       li[completed] {
-        text-decoration: line-through;
+        // text-decoration: line-through;
+        font-style: italic;
       }
 
       li[selected], li[selected] a {

--- a/assets/scss/codelab/_main.scss
+++ b/assets/scss/codelab/_main.scss
@@ -71,7 +71,7 @@ nav.doks-subnavbar, [data-dark-mode] nav.doks-subnavbar {
       li[completed]::after {
         content: "✓";
         font-style: normal;
-        color: #f05e3e;
+        color: $primary;
         font-weight: 900;
       }
 
@@ -121,6 +121,10 @@ nav.doks-subnavbar, [data-dark-mode] nav.doks-subnavbar {
 [data-dark-mode] body .codelab {
 
   .codelab-drawer .codelab-steps ol {
+
+    li[completed]::after {
+      color: $highlight;
+    }
 
     li, li a {
       color: $gray-300;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
fixes #180

**- What I did**
remove strikethrough styling from visited links in tutorial nav pane. To add other styling instead

**- How I did it**
currently discussions are up, continuing from issue #180 

**- How to verify it**
after deploying the changes, visit  /tutorials/at-dude/2-getting_started/ visit any one of the topics, then go to next topic, now see the changes in previous topic's appearance.

**- Description for the changelog**
remove strikethrough styling from visited links in tutorial nav pane, adding some other styling.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->