### PR TITLE
fix: compare base url with list of full urls

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -1,3 +1,6 @@
+ProductionURLs:
+  - 'https://docs.atsign.com/'
+
 # Theme Color for Chrome Browser
 
 themeColor: '#fff'

--- a/layouts/docs/codelab.html
+++ b/layouts/docs/codelab.html
@@ -1,7 +1,7 @@
 {{ define "main" }} {{ $section := .CurrentSection }} {{ $page := .Page }}
   {{ .Scratch.Set "class" "codelab" }}
   {{ if eq .CurrentSection.Params.layout "codelab-list" }}
-  {{ if ne (.Site.BaseURL) "https://docs.atsign.com" -}}
+  {{ if not (in .Site.Params.ProductionURLs (string .Site.BaseURL)) -}}
     {{ $options := (dict "targetPath" "codelab.css" "enableSourceMap" true "includePaths" (slice "node_modules")) -}}
     {{ $css := resources.Get "scss/codelab.scss" | toCSS $options -}}
     <link rel="stylesheet" href="{{ $css.Permalink | relURL }}">

--- a/layouts/partials/footer/script-footer.html
+++ b/layouts/partials/footer/script-footer.html
@@ -62,7 +62,7 @@
 
 {{ $js := $slice | resources.Concat "main.js" -}}
 
-{{ if ne (.Site.BaseURL) "https://docs.atsign.com" -}}
+{{ if not (in .Site.Params.ProductionURLs (string .Site.BaseURL)) -}}
   {{ if .Site.Params.options.bootStrapJs -}}
     <script src="{{ $bs.RelPermalink }}" defer></script>
   {{ end -}}

--- a/layouts/partials/head/script-header.html
+++ b/layouts/partials/head/script-header.html
@@ -6,7 +6,7 @@
   {{ $alertInit := resources.Get "js/alert-init.js" | js.Build | minify -}}
   <script>{{ $alertInit.Content | safeJS }}</script>
 {{- end -}}
-{{ if eq (.Site.BaseURL) "https://docs.atsign.com" -}}
+{{ if in .Site.Params.ProductionURLs (string .Site.BaseURL) -}}
   {{ $matomo := resources.Get "js/matomo.js" | js.Build | minify -}}
   <script>{{ $matomo.Content | safeJS }}</script>
 {{ end -}}

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,5 +1,5 @@
 User-agent: *
-{{ if eq (.Site.BaseURL) "https://docs.atsign.com"  -}}
+{{ if in .Site.Params.ProductionURLs (string .Site.BaseURL) -}}
 Allow: /
 {{ else -}}
 Disallow: /

--- a/layouts_docs/_default/codelab.html
+++ b/layouts_docs/_default/codelab.html
@@ -1,7 +1,7 @@
 {{ define "main" }} {{ $section := .CurrentSection }} {{ $page := .Page }}
   {{ .Scratch.Set "class" "codelab" }}
   {{ if eq .CurrentSection.Params.layout "codelab-list" }}
-  {{ if ne (.Site.BaseURL) "https://docs.atsign.com" -}}
+  {{ if not (in .Site.Params.ProductionURLs (string .Site.BaseURL)) -}}
     {{ $options := (dict "targetPath" "codelab.css" "enableSourceMap" true "includePaths" (slice "node_modules")) -}}
     {{ $css := resources.Get "scss/codelab.scss" | toCSS $options -}}
     <link rel="stylesheet" href="{{ $css.Permalink | relURL }}">


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added a "ProductionURLs" parameter to the site configuration.
Anywhere we need to do a production environment check, we now check against the list of ProductionURLs. This means we no longer need to do inline checks, as we were having issues with the BaseURL.

**- How I did it**

Local changes

**- How to verify it**

Ran `npm run build:production` locally, expect public/robots.txt to contain the line: `Allow: /` which it does.

**- Description for the changelog**
fix: compare base url with list of full urls
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->