### PR TITLE
fix: Use personal access token for DeployStaging Action

### DIFF
--- a/.github/workflows/DeployStaging.yaml
+++ b/.github/workflows/DeployStaging.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Deploy Staging
         uses: peaceiris/actions-gh-pages@de7ea6f8efb354206b205ef54722213d99067935 # v3
         with:
-          personal_token: ${{ secrets.GITHUB_TOKEN }}
+          personal_token: ${{ secrets.MY_GITHUB_TOKEN }}
           publish_dir: ./public
           publish_branch: gh-pages
           cname: ${{ env.URL }}


### PR DESCRIPTION
Actions run [#118](https://github.com/atsign-foundation/docs.atsign.com/actions/runs/3515904379/jobs/5891755829) failed due to a permissions problem.

**- What I did**

Use MY_GITHUB_TOKEN rather than GITHUB_TOKEN

**- How to verify it**

Next run of DeployStaging should work.

**- Description for the changelog**

fix: Use personal access token for DeployStaging Action