### PR TITLE
docs: Add OpenSSF Best Practices badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![GitHub License](https://img.shields.io/badge/license-BSD3-blue.svg)](./LICENSE)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/docs.atsign.com/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/docs.atsign.com)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8137/badge)](https://www.bestpractices.dev/projects/8137)
 
 # docs.atsign.com
 


### PR DESCRIPTION
Improving our OpenSSF Scorecard requires the badge to be found.

**- What I did**

Added OpenSSF Best practice badge to README

**- How I did it**

Pasted in link provided at https://www.bestpractices.dev/en/projects/8137

**- How to verify it**

Badge is visible in rich diff preview

**- Description for the changelog**

docs: Add OpenSSF Best practice badge to README